### PR TITLE
Simplify documentation landing page fix

### DIFF
--- a/website/static/index.html
+++ b/website/static/index.html
@@ -21,7 +21,7 @@
 <body class="sideNavVisible separateOnPageNav">
 
 <div class="fixedHeaderContainer"><div class="headerWrapper wrapper"><header><a href="/"><img class="logo" src="/img/Prince-logo.png" alt="Prince - Convert HTML to PDF with CSS"/></a><div class="navigationWrapper navigationSlider"><nav class="slidingNav"><ul class="nav-site nav-site-internal"><li class="siteNavGroupActive"><a href="/doc/" target="_self">Documentation</a></li><li class=""><a href="/doc/help" target="_self">Help</a></li><li class=""><a href="/doc/releases" target="_self">Release Notes</a></li><li class="navSearchWrapper reactNavSearchWrapper"><input type="text" id="search_input_react" placeholder="Search" title="Search"/></li></ul></nav></div></header></div></div>
-<div class="wrapper" style="padding-top: 60px; min-height: calc(100vh - 108px);">
+<div class="wrapper" style="padding-top: 60px; flex: 1;">
 <h1 class="title" id="idx">Prince Documentation</h1>
 <p class="copyright">Copyright © 2002-2020 YesLogic Pty Ltd</p>
 <h2 id="idx-contens">User Guide and Reference Guide</h2>


### PR DESCRIPTION
A quick follow-up to commit faba8445. It looks like a `min-height: 100vh` style is already active on `body`, so we may be able to get away with setting `flex: 1` on the wrapper `div` without having to compute its min height (and thus avoiding the hard-coding of the footer height).