### PR TITLE
Fix JavaScript Support page

### DIFF
--- a/docs/js-support.md
+++ b/docs/js-support.md
@@ -4,9 +4,10 @@ title: JavaScript Support
 sidebar_label: JavaScript Support
 ---
 
+import JsSupport from '../src/pages/js-support'
+
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
 <link href="https://fonts.googleapis.com/css2?family=Public+Sans:ital,wght@0,100..900;1,100..900&amp;display=swap" rel="stylesheet"/>
 
-import JsSupport from '../src/pages/js-support'
 <JsSupport />

--- a/src/pages/js-support/index.js
+++ b/src/pages/js-support/index.js
@@ -7,6 +7,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from '../index.module.css';
 
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import JavascriptSupportItem from '../../components/JavascriptSupportItem';
 import std from '/js/std';
 import stdAnnotated from '/js/std-annotated';
@@ -38,16 +39,20 @@ function JsSupport() {
   </p>
 
   <div className="js-overview level" id="js-support-table">
-  <JavascriptSupportItem
-    path={['window']}
-    name="window"
-    uaObject={window}
-    desc="The global object"
-    ext={null}
-    dumpedPropertyList={std}
-    open={true}
-    annotations={stdAnnotated}
-  />
+    <BrowserOnly fallback={<div>Loading...</div>}>
+      {() => (
+        <JavascriptSupportItem
+          path={['window']}
+          name="window"
+          uaObject={window}
+          desc="The global object"
+          ext={null}
+          dumpedPropertyList={std}
+          open={true}
+          annotations={stdAnnotated}
+        />
+      )}
+    </BrowserOnly>
 
 
   </div>


### PR DESCRIPTION
This PR fixes the JavaScript Support page so that it renders when running `yarn run start` and `yarn run build`

The reason it was previously breaking in development (`yarn start`) was because imports generally must appear at the top (apparently with the exception of front-matter).

The reason it was breaking the production build (`yarn build`) was because the `JavascriptSupportItem` component accesses the `window` object and the `location`. Because [Docusaurus v3's static site generation](https://docusaurus.io/docs/advanced/ssg) statically renders the HTML at build time using Node.js, there is no browser and no `window` object available. You can specify this chunk of code as client-side code by wrapping it in a [`BrowserOnly`](https://docusaurus.io/docs/docusaurus-core#browseronly) component and adding a function to call the client-side code only when the page has actually loaded in a browser.

The approach in this PR uses `BrowserOnly` so when the statically generated HTML will only contain `<div>Loading...</div>`. When the HTML page is first loaded, it will only show "Loading…", then JavaScript will kick in to fetch the rest of the content and replace the fallback. On slow connections, the "Loading..." text will be visible for a moment.

At the moment, links to specific documentation items like `http://localhost:3000/doc/js-support#window.parseFloat` will only scroll to that heading in a production build i.e. when you use `yarn run build && yarn run serve` and not `yarn run start` because of how [Docusaurus's dev server](https://docusaurus.io/docs/cli#docusaurus-start-sitedir) works:

> Please note that some functionality (for example, anchor links) will not work in development. The functionality will work as expected in production.