### PR TITLE
Reduce escaping needed in Docusaurus v3 CSS Props page template literal

### DIFF
--- a/src/pages/css-props/_cssPropsHtml.js
+++ b/src/pages/css-props/_cssPropsHtml.js
@@ -1,6 +1,6 @@
 // NOTE: The _cssPropsHtml.js file is an automatically generated file in the
 // properties/Makefile build process.
-const cssPropsHtml = `
+const cssPropsHtml = String.raw`
   <div id="prop-list">
     <details>
       <summary>
@@ -17248,17 +17248,17 @@ supplier, item { overflow-wrap: normal; }
     paragraphs.
     </p>
           <p>
-    The <code>\*-greedy</code> and <code>\*-lookahead</code> variations
+    The <code>*-greedy</code> and <code>*-lookahead</code> variations
     allow control over whether the choice of where to end a line
     can be affected by consequences further down the paragraph:
     </p>
           <p>
-    The <code>\*-greedy</code> keywords decide on line breaks solely based on the
+    The <code>*-greedy</code> keywords decide on line breaks solely based on the
     current line and on the length of the next word, never going back to change a
     decision on a line in the light of line-breaking issues encountered later.
     </p>
           <p>
-    The <code>\*-lookahead</code> keywords, on the other hand,
+    The <code>*-lookahead</code> keywords, on the other hand,
     enable paragraph-at-a-time line-breaking for the paragraph in
     a non-justified paragraph:
     choosing where to end the line not just based on what seems best for
@@ -20542,8 +20542,8 @@ supplier, item { overflow-wrap: normal; }
     or
     <code>-<a href="#prop-prince-resize-options">prince-resize-options</a></code>.
     </p>
-          <p>The <code>\*-start</code> values adjust space before the box’s content,
-    <code>\*-end</code> values adjust space after the box’s content,
+          <p>The <code>*-start</code> values adjust space before the box’s content,
+    <code>*-end</code> values adjust space after the box’s content,
     while the plain <code>margin</code> and <code>padding</code>
     values add half of the space adjustment before and half after.</p>
           <p class="note">
@@ -21136,8 +21136,8 @@ blockquote { margin: 1rem; -prince-resize-options: -1rem; }
             <div class="programlisting">
               <pre>
                 <code class="hljs">body {
-  -prince-text-replace: "s" "\\017F"
-                        "\\017F\\20" "s\\20";
+  -prince-text-replace: "s" "\017F"
+                        "\017F\20" "s\20";
 }</code>
               </pre>
             </div>
@@ -21230,17 +21230,17 @@ blockquote { margin: 1rem; -prince-resize-options: -1rem; }
     paragraphs.
     </p>
           <p>
-    The <code>\*-greedy</code> and <code>\*-lookahead</code> variations
+    The <code>*-greedy</code> and <code>*-lookahead</code> variations
     allow control over whether the choice of where to end a line
     can be affected by consequences further down the paragraph:
     </p>
           <p>
-    The <code>\*-greedy</code> keywords decide on line breaks solely based on the
+    The <code>*-greedy</code> keywords decide on line breaks solely based on the
     current line and on the length of the next word, never going back to change a
     decision on a line in the light of line-breaking issues encountered later.
     </p>
           <p>
-    The <code>\*-lookahead</code> keywords, on the other hand,
+    The <code>*-lookahead</code> keywords, on the other hand,
     enable paragraph-at-a-time line-breaking for the paragraph in
     a non-justified paragraph:
     choosing where to end the line not just based on what seems best for

--- a/src/properties/css-props-partial-header.txt
+++ b/src/properties/css-props-partial-header.txt
@@ -1,3 +1,3 @@
 // NOTE: The _cssPropsHtml.js file is an automatically generated file in the
 // properties/Makefile build process.
-const cssPropsHtml = `
+const cssPropsHtml = String.raw`

--- a/src/properties/properties.xml
+++ b/src/properties/properties.xml
@@ -2,10 +2,9 @@
 
 <!--
 
-NOTE: The current build process will cause this file's content to appear in a JavaScript template literal so we must backslash escape anything that would cause errors in a JavaScript template literal, such as string interpolated expressions starting with dollar curly brace and any escape sequences, including hexadecimal escape sequences, unicode escape sequences and unicode code point escapes. For example:
+NOTE: The current build process will cause this file's content to appear in a JavaScript template literal using String.raw so we must backslash string interpolated expressions starting with dollar curly brace. For example:
 
 - change `${}` to `\${}` or `$\{}`
-- change `\017F` to `\\017F`
 
 -->
 
@@ -6016,19 +6015,19 @@ supplier, item { overflow-wrap: normal; }
     </p>
 
     <p>
-    The <code>\*-greedy</code> and <code>\*-lookahead</code> variations
+    The <code>*-greedy</code> and <code>*-lookahead</code> variations
     allow control over whether the choice of where to end a line
     can be affected by consequences further down the paragraph:
     </p>
 
     <p>
-    The <code>\*-greedy</code> keywords decide on line breaks solely based on the
+    The <code>*-greedy</code> keywords decide on line breaks solely based on the
     current line and on the length of the next word, never going back to change a
     decision on a line in the light of line-breaking issues encountered later.
     </p>
 
     <p>
-    The <code>\*-lookahead</code> keywords, on the other hand,
+    The <code>*-lookahead</code> keywords, on the other hand,
     enable paragraph-at-a-time line-breaking for the paragraph in
     a non-justified paragraph:
     choosing where to end the line not just based on what seems best for
@@ -7433,8 +7432,8 @@ supplier, item { overflow-wrap: normal; }
     <code><property name="prince-resize-options"/></code>.
     </p>
 
-    <p>The <code>\*-start</code> values adjust space before the box’s content,
-    <code>\*-end</code> values adjust space after the box’s content,
+    <p>The <code>*-start</code> values adjust space before the box’s content,
+    <code>*-end</code> values adjust space after the box’s content,
     while the plain <code>margin</code> and <code>padding</code>
     values add half of the space adjustment before and half after.</p>
 
@@ -7692,8 +7691,8 @@ blockquote { margin: 1rem; -prince-resize-options: -1rem; }
     <inherit>no</inherit>
     <extension/>
     <example>body {
-  -prince-text-replace: "s" "\\017F"
-                        "\\017F\\20" "s\\20";
+  -prince-text-replace: "s" "\017F"
+                        "\017F\20" "s\20";
 }</example>
     <see><a href="/doc/characters/">Character Entities</a></see>
     <comments>

--- a/src/properties/properties.xml
+++ b/src/properties/properties.xml
@@ -2,6 +2,15 @@
 
 <!--
 
+NOTE: The current build process will cause this file's content to appear in a JavaScript template literal so we must backslash escape anything that would cause errors in a JavaScript template literal, such as string interpolated expressions starting with dollar curly brace and any escape sequences, including hexadecimal escape sequences, unicode escape sequences and unicode code point escapes. For example:
+
+- change `${}` to `\${}` or `$\{}`
+- change `\017F` to `\\017F`
+
+-->
+
+<!--
+
  - "related properties"?
  - how percentage/relative values apply
  - how to properly display font-family value?


### PR DESCRIPTION
This PR reduces the amount of backslash escaping needed in `properties.xml` content.

It adds the [`String.raw`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw) static method tag function of [template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to the `cssPropsHtml` template literal (via `src/properties/css-props-partial-header.txt`) so that we get the raw string form of template literals without escape sequences processed.

This PR also adds a header comment to the `properties.xml` file so it's clear what escaping *is* needed.