### PR TITLE
Update Docusaurus v3 CSS Properties page interactions

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -321,7 +321,7 @@ table.property-table td {
 #prop-list summary#prop---custom-property-name, #prop-list summary#prop---custom-property-name + div .example .syntax-block > code {
     font-style: italic;
 }
-dt[id], h6[id], th[id], summary[id] {
+dt[id], h6[id], th[id], summary[id], #prop-list div[id] {
     scroll-margin-top: calc(var(--ifm-navbar-height) + 1rem);
 }
 

--- a/src/pages/css-props/index.js
+++ b/src/pages/css-props/index.js
@@ -1,8 +1,47 @@
+import { useEffect } from "react";
 import cssPropsHtml from "./_cssPropsHtml";
 
 function CssProperties() {
-  // TODO: on click of hash-link (i.e. on hashchange), open/close details
-  // TODO: on load, open details for URL hash item
+  useEffect(() => {
+    // On page load/after first render, if there's a hash in the URL, open that id's parent `details` element:
+    const hash = window.location.hash;
+    if (hash) {
+      const id = hash.substring(1); // Remove the '#' from the hash
+      const element = document.getElementById(id);
+      if (element) {
+        let parentDetails = element.parentNode;
+        while (parentDetails && parentDetails.tagName !== "DETAILS") {
+          parentDetails = parentDetails.parentNode;
+        }
+        if (parentDetails) {
+          parentDetails.setAttribute("open", "");
+        }
+      }
+    }
+
+    // On "hashchange"/click of hash-links, open the corresponding id's parent `details` element:
+    window.addEventListener("hashchange", () => {
+      const hash = window.location.hash;
+      if (hash) {
+        const id = hash.substring(1); // Remove the '#' from the hash
+        const element = document.getElementById(id);
+        if (element) {
+          let parentDetails = element.parentNode;
+          while (parentDetails && parentDetails.tagName !== "DETAILS") {
+            parentDetails = parentDetails.parentNode;
+          }
+          if (parentDetails && !parentDetails.hasAttribute("open")) {
+            parentDetails.setAttribute("open", "");
+          }
+        }
+      }
+    });
+
+    // When the css-props component unmounts, remove the hashchange event listener:
+    return () => {
+      window.removeEventListener("hashchange", () => {});
+    };
+  }, []);
 
   const toggleAllCSS = (event) => {
     const propListEl = document.getElementById("prop-list");

--- a/src/pages/css-props/index.js
+++ b/src/pages/css-props/index.js
@@ -1,6 +1,24 @@
 import { useEffect, useMemo } from "react";
 import cssPropsHtml from "./_cssPropsHtml";
 
+function openDetails() {
+  const hash = window.location.hash;
+  if (hash) {
+    const id = hash.substring(1); // Remove the '#' from the hash
+    const element = document.getElementById(id);
+    if (element) {
+      let parentDetails = element.parentNode;
+      while (parentDetails && parentDetails.tagName !== "DETAILS") {
+        parentDetails = parentDetails.parentNode;
+      }
+      if (parentDetails) {
+        parentDetails.setAttribute("open", "");
+        element.scrollIntoView(); // This is necessary to scroll to IDs inside collapsed `details` elements over a slow connection
+      }
+    }
+  }
+}
+
 function CssProperties() {
   // This prevents *other* sections closing when the URL hash changes on hash-link clicks and the page re-renders:
   const memoizedCssPropsHtml = useMemo(
@@ -12,39 +30,11 @@ function CssProperties() {
 
   useEffect(() => {
     // On page load/after first render, if there's a hash in the URL, open that id's parent `details` element:
-    const hash = window.location.hash;
-    if (hash) {
-      const id = hash.substring(1); // Remove the '#' from the hash
-      const element = document.getElementById(id);
-      if (element) {
-        let parentDetails = element.parentNode;
-        while (parentDetails && parentDetails.tagName !== "DETAILS") {
-          parentDetails = parentDetails.parentNode;
-        }
-        if (parentDetails) {
-          parentDetails.setAttribute("open", "");
-          element.scrollIntoView(); // This is necessary to scroll to IDs inside collapsed `details` elements over a slow connection
-        }
-      }
-    }
+    openDetails();
 
     // On "hashchange"/click of hash-links, open the corresponding id's parent `details` element:
     window.addEventListener("hashchange", () => {
-      const hash = window.location.hash;
-      if (hash) {
-        const id = hash.substring(1); // Remove the '#' from the hash
-        const element = document.getElementById(id);
-        if (element) {
-          let parentDetails = element.parentNode;
-          while (parentDetails && parentDetails.tagName !== "DETAILS") {
-            parentDetails = parentDetails.parentNode;
-          }
-          if (parentDetails && !parentDetails.hasAttribute("open")) {
-            parentDetails.setAttribute("open", "");
-            element.scrollIntoView(); // This is necessary to scroll to IDs inside collapsed `details` elements over a slow connection
-          }
-        }
-      }
+      openDetails();
     });
 
     // When the css-props component unmounts, remove the hashchange event listener:

--- a/src/pages/css-props/index.js
+++ b/src/pages/css-props/index.js
@@ -15,6 +15,7 @@ function CssProperties() {
         }
         if (parentDetails) {
           parentDetails.setAttribute("open", "");
+          element.scrollIntoView(); // This is necessary to scroll to IDs inside collapsed `details` elements over a slow connection
         }
       }
     }
@@ -32,6 +33,7 @@ function CssProperties() {
           }
           if (parentDetails && !parentDetails.hasAttribute("open")) {
             parentDetails.setAttribute("open", "");
+            element.scrollIntoView(); // This is necessary to scroll to IDs inside collapsed `details` elements over a slow connection
           }
         }
       }

--- a/src/pages/css-props/index.js
+++ b/src/pages/css-props/index.js
@@ -33,13 +33,11 @@ function CssProperties() {
     openDetails();
 
     // On "hashchange"/click of hash-links, open the corresponding id's parent `details` element:
-    window.addEventListener("hashchange", () => {
-      openDetails();
-    });
+    window.addEventListener("hashchange", openDetails);
 
     // When the css-props component unmounts, remove the hashchange event listener:
     return () => {
-      window.removeEventListener("hashchange", () => {});
+      window.removeEventListener("hashchange", openDetails);
     };
   }, []);
 

--- a/src/pages/css-props/index.js
+++ b/src/pages/css-props/index.js
@@ -1,7 +1,15 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import cssPropsHtml from "./_cssPropsHtml";
 
 function CssProperties() {
+  // This prevents *other* sections closing when the URL hash changes on hash-link clicks and the page re-renders:
+  const memoizedCssPropsHtml = useMemo(
+    () => ({
+      __html: cssPropsHtml,
+    }),
+    [cssPropsHtml]
+  );
+
   useEffect(() => {
     // On page load/after first render, if there's a hash in the URL, open that id's parent `details` element:
     const hash = window.location.hash;
@@ -146,7 +154,7 @@ function CssProperties() {
             Toggle (open/close) all properties
           </a>
         </p>
-        <div dangerouslySetInnerHTML={{ __html: cssPropsHtml }}></div>
+        <div dangerouslySetInnerHTML={memoizedCssPropsHtml}></div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR matches existing Prince docs site behaviour for the CSS Properties page in terms of opening sections and scrolling to sections from URLs with hashes and clicking on hash-link anchors.

This PR also adds support for linking to IDs within a closed section and opening/scrolling to them. (See the scenarios marked `[NEW]` below.)

Tested scenarios in Firefox on macOS:

- [x] Given a `css-props` page URL with CSS property hash like <http://localhost:3000/doc/css-props/#prop-accent-color>, when I open it in a new tab on a slow/throttled connection, then it opens that section and its summary/heading is visible below the nav bar
- [x] Given a `css-props` page URL with a hash that matches an `id` inside a `<details>` element like <http://localhost:3000/doc/css-props/#prop---custom-property-name-seealso> on a slow/throttled connection, when I open it in a new tab, then it opens that section and the element with that `id` is visible below the nav bar [NEW]
- [x] Given I'm on the `css-props` page, when I click on a closed section's summary, then it opens that section without scrolling
- [x] Given I'm on the `css-props` page, when I click on a closed section's summary, then it opens that section without closing any other section
- [x] Given I'm on the `css-props` page, when I click on an open section's summary, then it closes that section without scrolling
- [x] Given I'm on the `css-props` page, when I click on an open section's summary, then it closes that section without closing any other section
- [x] Given I'm on the `css-props` page, when I click on an open section's details/body, then it does nothing/does not close the section
- [x] Given I'm on the `css-props` page, when I click on a closed section's hash-link, then it opens that section, updates the URL hash, and shows the summary/heading just below the nav bar
- [x] Given I'm on the `css-props` page, when I click on a closed section's hash-link, then it opens that section without closing any other section
- [x] Given I'm on the `css-props` page without a hash in the URL, when I click on an open section's hash-link, then it updates the URL hash and shows the summary/heading just below the nav bar, without closing the section
- [x] Given I'm on the `css-props` page without a hash in the URL, when I click on an open section's hash-link, then it updates the URL hash without closing any other section
- [x] Given I'm on another Prince docs page like <http://localhost:3000/doc/characters> that links to the `css-props` page with a CSS property hash like <http://localhost:3000/doc/css-props#prop-prince-text-replace>, when I click on the link, then it navigates to the page, opens that section, and its summary/heading is visible below the nav bar
- [x] Given I'm on the `css-props` page with all sections closed, when I first click on the toggle all link, then opens all sections
- [x] Given I'm on the `css-props` page with all sections open, when I click on an open section's summary, then it closes that section
- [x] Given I'm on the `css-props` page with some sections open, when I click on the toggle all link for the second time, then it closes all sections
- [x] Given I'm on the `css-props` page with all sections closed, when I click on a closed section's summary to open it and then click the toggle all link for the first (or third) time, then it opens all sections
- [x] Given I'm on the newly loaded `css-props` page, when I manually open all closed sections and click the toggle all link for the first time, then it appears to do nothing/opens all the already-open sections
- [x] Given a `css-props` page URL with CSS property hash like <http://localhost:3000/doc/css-props/#prop-z-index>, when I open it in a new tab (which opens the section) and first click on the toggle all link, then it opens all remaining sections
- [x] Given I'm on the `css-props` page without a hash URL, when I click on a summary heading like `accent-color` to open it and then click its hash-link, then it updates the URL with the hash and moves to that section's heading and keeps the section open
- [x] Given I'm on the `css-props` page with a hash in the URL like <http://localhost:3000/doc/css-props/#prop-accent-color>, when I click on a summary heading to close it and then click its hash-link, then the URL with the hash stays the same and the browser moves to that section's heading and keeps the section closed
- [x] Given a `css-props` page URL with a hash that matches an `id` inside a `<details>` element like <http://localhost:3000/doc/css-props/#prop---custom-property-name-seealso>, when I open it in a new tab and click the section to close it and then click that section's hash-link, then it opens that section, updates the URL hash, and moves to the heading [NEW]
- [x] Given I'm on the `css-props` page with a hash in the URL like <http://localhost:3000/doc/css-props/#prop-accent-color>, when I click on another section's hash-link like <http://localhost:3000/doc/css-props/#prop-align-content> to open it and close the first section and click the browser back button, then it updates the URL hash to the first section, opens the first section again, moves to that section's heading and keeps the second section open

I also tested the main scenarios with Chromium.